### PR TITLE
Support promise

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -4,6 +4,7 @@ var request = require('request');
 var fs = require('fs');
 var path = require('path');
 var apis = require('./apis').loadDefault();
+var util = require('util');
 
 function authFromOption(options) {
   var header = {};
@@ -100,15 +101,15 @@ function kintone(domain, authorization) {
       } else {
         head[key] = (function(linkStr) {
           Object.freeze(linkStr);
-          return function(data, callback) {
+          return util.promisify(function(data, callback) {
             return requestBase(linkStr, data, callback);
-          };
+          });
         }(apis[i].split('/')));
       }
     }
   }
 
-  kintone.prototype.file.post = function(filename, callback) {
+  kintone.prototype.file.post = util.promisify(function(filename, callback) {
     var options = {
       url: 'https://' + domain + '/k/v1/file.json',
       headers: {},
@@ -129,7 +130,7 @@ function kintone(domain, authorization) {
     request(options, function(err, response, body) {
       callback(err, JSON.parse(body));
     });
-  };
+  });
 }
 
 module.exports = kintone;

--- a/test/promiseTest.js
+++ b/test/promiseTest.js
@@ -1,0 +1,22 @@
+'use strict';
+
+var kintone = require('../lib');
+var expect = require('chai').expect;
+var nock = require('nock');
+
+describe('promise', function() {
+
+  afterEach(function() {
+    nock.cleanAll();
+  });
+
+  it('returns promise when no callback is provided', function(done) {
+    var scope = nock('https://example.cybozu.com').get('/k/v1/app.json').reply(200, '{}');
+    var api = new kintone('example', { 'token': 'loremipsum' });
+
+    api.app.get({}).then(function() {
+      expect(scope.isDone()).to.be.true;
+      done();
+    });
+  });
+});


### PR DESCRIPTION
Wrap functions with util.promisify

もう一点、別件でPR送らせてもらいます。
`util.promisify()` を使って各関数をラップしてみました。

これでPromiseでの非同期処理もできますし、
callbackが渡されればPromiseは返さないので、
既存のコードの互換性も保たれると思います。
テストも単独モジュールとして1つ書いてみましたが、どうでしょうか・・・